### PR TITLE
feat: support uid only form in NormalizeUidGid

### DIFF
--- a/internals/osutil/export_test.go
+++ b/internals/osutil/export_test.go
@@ -39,6 +39,12 @@ func FakeUserLookup(f func(name string) (*user.User, error)) func() {
 	return func() { userLookup = oldUserLookup }
 }
 
+func FakeUserLookupId(f func(name string) (*user.User, error)) func() {
+	oldUserLookupId := userLookupId
+	userLookupId = f
+	return func() { userLookupId = oldUserLookupId }
+}
+
 func FakeUserLookupGroup(f func(name string) (*user.Group, error)) func() {
 	oldUserLookupGroup := userLookupGroup
 	userLookupGroup = f

--- a/internals/osutil/user.go
+++ b/internals/osutil/user.go
@@ -131,7 +131,8 @@ func NormalizeUidGid(uid, gid *int, username, group string) (*int, *int, error) 
 		gid = &n
 	}
 	if gid == nil {
-		// Group not specified; use user's primary group ID
+		// Neither gid nor group was specified
+		// Either uid or user must have been specified; use user's primary group ID
 		uidInfo, err := userLookupId(strconv.Itoa(*uid))
 		if err != nil {
 			if strings.Contains(err.Error(), enoentMessage) {


### PR DESCRIPTION
This makes it valid to supply just the uid for operations setting file ownership, like mkdir and push.